### PR TITLE
Allow soagen to compile with -fno-exceptions

### DIFF
--- a/src/soagen/hpp/allocator.hpp
+++ b/src/soagen/hpp/allocator.hpp
@@ -103,9 +103,13 @@ namespace soagen
 #else
 			auto ptr = static_cast<pointer>(std::aligned_alloc(static_cast<size_t>(alignment), size));
 #endif
+
+#if SOAGEN_HAS_EXCEPTIONS
 			if SOAGEN_UNLIKELY(!ptr)
 				throw std::bad_alloc{};
-
+#else
+			assert(ptr);
+#endif
 			return soagen::assume_aligned<min_alignment>(ptr);
 		}
 

--- a/src/soagen/hpp/table.hpp
+++ b/src/soagen/hpp/table.hpp
@@ -743,7 +743,13 @@ namespace soagen::detail
 			// hit system limits and have no choice but to raise std::bad_alloc.
 			auto new_size = base::count_;
 			if SOAGEN_UNLIKELY(!add_without_overflowing(new_size, new_elements, new_size) || new_size > max_capacity)
+			{
+#if SOAGEN_HAS_EXCEPTIONS
 				throw std::bad_alloc{};
+#else
+				assert(false);
+#endif
+			}
 
 			// already enough capacity, no work to do.
 			if SOAGEN_LIKELY(new_size <= base::capacity())


### PR DESCRIPTION

**What does this change do?**

The changes replaces throwing with ``assert(false)`` if we don't have SOAGEN_HAS_EXCEPTIONS

**Is it related to an exisiting bug report or feature request?**

<!--
    Fixes #69.
--->

**Pre-merge checklist**

<!--
    Not all of these will necessarily apply, particularly if you're not making a code change (e.g. fixing documentation).
    That's OK. Tick the ones that do by placing an x in them, e.g. [x]
--->

-   [x] I've read [CONTRIBUTING.md]
-   [x] I've rebased my changes against the current HEAD of `origin/main` (if necessary)
-   [ ] I've added new test cases to verify my change (if applicable)
-   [ ] I've updated any affected documentation
-   [x] I've tested my changes
-   [x] I've regenerated the single-header version of `soagen.hpp` ([how-to])

[CONTRIBUTING.md]: https://github.com/marzer/soagen/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/soagen/blob/master/CONTRIBUTING.md#modifying-soagenhpp
